### PR TITLE
iconv('UTF-8', 'ASCII//TRANSLIT', ...) doesn't work properly when locale category LC_CTYPE is set to C or POSIX

### DIFF
--- a/services/Url.php
+++ b/services/Url.php
@@ -368,7 +368,9 @@ class Url extends Service
      */
     protected function generateUrlByName($name)
     {
+        setlocale(LC_ALL, '');
         $url = iconv('UTF-8', 'ASCII//TRANSLIT', $name);
+
         $url = preg_replace('{[^a-zA-Z0-9_.| -]}', '', $url);
         $url = strtolower(trim($url, '-'));
         $url = preg_replace('{[_| -]+}', '-', $url);


### PR DESCRIPTION
此bug出现在我的测试服务器上，造成管理后台商品分类保存时ajax请求502