### PR TITLE
改进安装向导

### DIFF
--- a/app/appinstall/assets/css/site.css
+++ b/app/appinstall/assets/css/site.css
@@ -1,22 +1,23 @@
-.body-container{
-    min-height: 900px;
-        margin-top: 50px;
-    padding-top: 20px;
+.body-container {
+  min-height: calc(100vh - 81px);
+  margin-top: 50px;
+  padding-top: 20px;
 }
 
 .error-msg {
-    margin:3px 0;
-	background: #faebe7 url("../images/i_msg-error.gif") no-repeat scroll 8px 7px;
-    border: 1px solid #f16048;
-    color: #df280a;
-    font-size: 0.8em;
-    padding: 5px 30px;
+  margin: 3px 0;
+  background: #faebe7 url("../images/i_msg-error.gif") no-repeat scroll 8px 7px;
+  border: 1px solid #f16048;
+  color: #df280a;
+  font-size: 0.8em;
+  padding: 5px 30px;
 }
+
 .correct-msg {
-    margin:3px 0;
-	background: #eff5ea url("../images/i_msg-success.gif") no-repeat scroll 8px 7px;
-    border: 1px solid #95a486;
-    color: #3d6611 ;
-    font-size: 0.8em;
-    padding: 5px 30px;
+  margin: 3px 0;
+  background: #eff5ea url("../images/i_msg-success.gif") no-repeat scroll 8px 7px;
+  border: 1px solid #95a486;
+  color: #3d6611;
+  font-size: 0.8em;
+  padding: 5px 30px;
 }

--- a/app/appinstall/modules/Database/views/config/index.php
+++ b/app/appinstall/modules/Database/views/config/index.php
@@ -1,39 +1,57 @@
 <?php
-    use fec\helpers\CRequest;
+
+use fec\helpers\CRequest;
+
 ?>
 <h1>Mysql数据库配置</h1>
 <br/>
 
-<?=  $errorInfo  ?>
+<?= $errorInfo ?>
 
 
 <form action="" method="post">
-    <?php echo CRequest::getCsrfInputHtml();  ?>	
-  <div class="form-group">
-    <label for="name">Mysql数据库Host</label>
-    <input type="text" class="form-control" value="<?= $editForm['host'] ?>" name="editForm[host]" placeholder="Mysql数据库Host Ip，本地请填写127.0.0.1">
-  </div>
-  
-  <div class="form-group">
-    <label for="name">Mysql数据库端口</label>
-    <input type="text" class="form-control" value="<?= $editForm['port'] ? $editForm['port'] : '3306' ?>" name="editForm[port]" placeholder="Mysql数据库port，请先去mysql中创建数据库，然后再填写">
-  </div>
-  
-  <div class="form-group">
-    <label for="name">Mysql数据库名称</label>
-    <input type="text" class="form-control" value="<?= $editForm['database'] ?>" name="editForm[database]" placeholder="Mysql数据库名称，请先去mysql中创建数据库，然后再填写">
-  </div>
-  
-  <div class="form-group">
-    <label for="name">Mysql数据库账户</label>
-    <input type="text" class="form-control" value="<?= $editForm['user'] ?>" name="editForm[user]" placeholder="Mysql数据库账户">
-  </div>
-  
-  <div class="form-group">
-    <label for="name">Mysql数据库密码</label>
-    <input type="text" class="form-control" value="<?= $editForm['password'] ?>" name="editForm[password]" placeholder="Mysql数据库密码">
-  </div>
-  
-  
-  <button type="submit" class="btn btn-default">提交</button>
+    <?php echo CRequest::getCsrfInputHtml(); ?>
+    <div class="form-group">
+        <label for="name">Mysql数据库Host</label>
+        <input type="text" class="form-control" value="<?= $editForm['host'] ? $editForm['host'] : 'localhost' ?>"
+               name="editForm[host]" placeholder="Mysql数据库Host，同服务器可填写 127.0.0.1 或 localhost">
+    </div>
+
+    <div class="form-group">
+        <label for="name">Mysql数据库端口</label>
+        <input type="text" class="form-control" value="<?= $editForm['port'] ? $editForm['port'] : '3306' ?>"
+               name="editForm[port]" placeholder="Mysql 数据库 port，默认：3306">
+    </div>
+
+    <div class="form-group">
+        <label for="name">Mysql数据库名称</label>
+        <input type="text" class="form-control" value="<?= $editForm['database'] ? $editForm['database'] : 'fecmall' ?>"
+               name="editForm[database]" placeholder="Mysql数据库名称，请确认数据库已创建。">
+    </div>
+
+    <div class="form-group">
+        <label for="name">Mysql数据库账户</label>
+        <input type="text" class="form-control" value="<?= $editForm['user'] ? $editForm['user'] : 'root' ?>"
+               name="editForm[user]" placeholder="Mysql数据库账户">
+    </div>
+
+    <div class="form-group">
+        <label for="name">Mysql数据库密码</label>
+        <input type="password" class="form-control" value="<?= $editForm['password'] ?>" name="editForm[password]"
+               placeholder="Mysql数据库密码">
+    </div>
+
+    <div class="form-group">
+        <label for="name">超级管理员账户</label>
+        <input type="text" class="form-control" value="<?= $editForm['username'] ? $editForm['username'] : 'admin' ?>"
+               name="editForm[username]" placeholder="超级管理员账户">
+    </div>
+
+    <div class="form-group">
+        <label for="name">超级账户密码</label>
+        <input type="password" class="form-control" required value="<?= $editForm['userpassword'] ?>"
+               name="editForm[userpassword]" placeholder="超级账户密码">
+    </div>
+
+    <button type="submit" class="btn btn-default">提交</button>
 </form>

--- a/models/mysqldb/AdminUser.php
+++ b/models/mysqldb/AdminUser.php
@@ -11,6 +11,7 @@ namespace fecshop\models\mysqldb;
 use Yii;
 use yii\db\ActiveRecord;
 use yii\web\IdentityInterface;
+
 /**
  * User model
  *
@@ -24,8 +25,13 @@ use yii\web\IdentityInterface;
  * @property integer $created_at
  * @property integer $updated_at
  * @property string $password write-only password
- */
-/**
+ * @property string $access_token
+ * @property int $access_token_created_at access token 创建时间戳
+ * @property int $allowance
+ * @property int $allowance_updated_at
+ * @property string $created_at_datetime
+ * @property string $updated_at_datetime
+ * @property string $birth_date
  * @author Terry Zhao <2358269014@qq.com>
  * @since 1.0
  */


### PR DESCRIPTION
安装向导增加超级账户设定【此变更仅在安装向导有效，手动迁移数据库不触发】

如果 `appfront/web` 目录无读写权限，访问安装向导时将会提示
`没有文件读写权限，请赋予 appfront/web 目录可读写权限。file_put_contents(install.lock): failed to open stream: Permission denied`

初始化数据库后将在 `appfront/web` 目录生成 `install.lock` 文件,再次运行 install 程序将会提示
`您的项目可能已安装成功，如果需要重新安装，请手动删除项目目录的 appfront/web/install.lock 文件`

数据库host 修改为 ：`localhost`
数据库默认库：fecmall
数据库默认账户：root
超级账户默认账户：admin
超级账户邮箱必填
超级账户密码必填

