### PR TITLE
docs(childService): wrong namespace in @Property annotation

### DIFF
--- a/services/Admin.php
+++ b/services/Admin.php
@@ -15,13 +15,13 @@ use Yii;
 /**
  * Admin services.
  *
- * @property \fecshop\services\customer\UrlKey $urlKey
- * @property \fecshop\services\customer\RoleUrlKey $roleUrlKey
- * @property \fecshop\services\customer\Role $role
- * @property \fecshop\services\customer\Config $config
- * @property \fecshop\services\customer\UserRole $userRole
- * @property \fecshop\services\customer\SystemLog $systemLog
- * @property \fecshop\services\customer\Menu $menu
+ * @property \fecshop\services\admin\UrlKey $urlKey
+ * @property \fecshop\services\admin\RoleUrlKey $roleUrlKey
+ * @property \fecshop\services\admin\Role $role
+ * @property \fecshop\services\admin\Config $config
+ * @property \fecshop\services\admin\UserRole $userRole
+ * @property \fecshop\services\admin\SystemLog $systemLog
+ * @property \fecshop\services\admin\Menu $menu
  *
  * @author Terry Zhao <2358269014@qq.com>
  * @since 1.0

--- a/services/AdminUser.php
+++ b/services/AdminUser.php
@@ -15,8 +15,8 @@ use Yii;
 /**
  * AdminUser services. 用来给后台的用户提供数据。
  *
- * @property \fecshop\services\customer\AdminUser $adminUser
- * @property \fecshop\services\customer\UserLogin $userLogin
+ * @property \fecshop\services\adminUser\AdminUser $adminUser
+ * @property \fecshop\services\adminUser\UserLogin $userLogin
  *
  * @author Terry Zhao <2358269014@qq.com>
  * @since 1.0

--- a/services/Cms.php
+++ b/services/Cms.php
@@ -11,8 +11,8 @@
 namespace fecshop\services;
 
 /**
- * @property \fecshop\services\customer\Article $article
- * @property \fecshop\services\customer\StaticBlock $staticblock
+ * @property \fecshop\services\cms\Article $article
+ * @property \fecshop\services\cms\StaticBlock $staticblock
  *
  * Cms services.
  * @author Terry Zhao <2358269014@qq.com>

--- a/services/Customer.php
+++ b/services/Customer.php
@@ -15,7 +15,7 @@ use yii\web\IdentityInterface;
 
 /**
  * Customer service.
- * @property \fecshop\services\Customer\Address $address
+ * @property \fecshop\services\customer\Address $address
  * @property \fecshop\services\customer\Newsletter $newsletter
  * @property \fecshop\services\customer\Affiliate $affiliate
  * @property \fecshop\services\customer\Coupon $coupon


### PR DESCRIPTION
Admin、AdminUser、Cms的Service，修改@property注解中错误的命名空间，方便IDE识别与跳转