### PR TITLE
增强shell脚本的兼容性

### DIFF
--- a/shell/search/fullSearchSync.sh
+++ b/shell/search/fullSearchSync.sh
@@ -14,7 +14,7 @@ pagenum=`$Cur_Dir/../../../../../yii product/search/syncpagenum`
 echo "There are $count products to process"
 echo "There are $pagenum pages to process"
 echo "##############ALL BEGINING###############";
-for (( i=1; i<=$pagenum; i++ ))
+for i in `seq $pagenum`
 do
    $Cur_Dir/../../../../../yii product/search/syncdata $i
    echo "Page $i done"


### PR DESCRIPTION
/bin/sh软链接的shell有可能是bash，dash，busybox等等，但不是所有shell支持C语言格式的for循环写法。